### PR TITLE
fix exception while loading images: handle not found resp. content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build/
 # Python egg metadata, regenerated from source files by setuptools.
 src/*.egg-info
 *.egg-info
+
+# virtual env files
+venv/

--- a/README.md
+++ b/README.md
@@ -31,16 +31,13 @@ In a terminal, run
 
 ```
 flowkey-dl
-
 ```
 
 ~~Go to flowkey.com, select a song or lesson and right click on the sheet track at the bottom of the page.~~
 ~~Flowkey made it harder to get the url of the underlying images, simply right click does not work anymore. It should still work when looking in the browsers cache. With google-chrome browser, you find it by clicking on the three dots in the top right -> more tools -> developer tools, then on the "sources" tab. Here you should find cdn.flowkey.com with a folder /sheets (or /rendered-sheets), with all the songs from the last session. Click right on the first image (0.png or 0@2x.png) and then 'copy link location'. There is probably similar ways in other browsers.~~
 Again, flowkey changed their backend, and the above procedure does not work anymore. You can get the image url programmatically, in the console of the web browser. with google-chrome browser, you find it by clicking on the three dots in the top right -> more tools -> developer tools, then on the "Console" tab. There you can paste in the following lines:
 ```
-var img = document.querySelector("div.sheet-image");
-var imgUrl = img.style.backgroundImage.slice(4, -1).replace(/"/g, "");
-console.log(imgUrl);
+document.querySelector("div.sheet-image").style.backgroundImage.slice(4, -1).replace(/"/g, "");
 ```
 
 Paste this url (e.g. https://cdn.flowkey.com/rendered-sheets/XXXXXXX/XXXXXXX/0@2x.png)) into the url filed of the app. Click on "load" and the sheet is downloaded and aranged. If you enter title and author, it gets added to the sheet. Optionally adjust layout, scale and font size and select measures (e.g. 1,3,5-10 would select only measures 1, 3 and 5 to 10). Click save to save the sheet as pdf.

--- a/src/flowkey_dl/flowkey_dl.py
+++ b/src/flowkey_dl/flowkey_dl.py
@@ -28,7 +28,7 @@ def flowkey_dl(url):
     while True:
         # im = imageio.imread(url.format(i))
         r = requests.get(url.format(i))
-        if r.content[-6:-1] == b"Error":
+        if r.content[-6:-1] == b"Error" or r.content == b'Not Found':
             break
         patch = imageio.imread(r.content, format='png', pilmode="RGBA")
         print(f"loaded patch {i} with shape {patch.shape}")


### PR DESCRIPTION
I was facing some issues when following the current readme. 
I managed to download sheets after updating the suggested browser console commands
( btw: For the song I used for testing, the image link did not change to the one shown in the sources ) 
and  caught the response content inside the while loop which is returned after the last image. 
In my test case "No content" was returned.
With this, I was able to run the app without any exception again :)
I also recommend to suggest using virtual environments when using a local version of the repo.